### PR TITLE
Removed 'specify jsonp' from spec description

### DIFF
--- a/spec/spotify-chart.spec.js
+++ b/spec/spotify-chart.spec.js
@@ -36,7 +36,7 @@ describe("spotifyChart", function(){
   });
 
   describe("#getSpotifyTracks", function(){
-    it("uses jQuery's ajax function to get json (specify JSONP)", function() {
+    it("uses jQuery's ajax function to get json", function() {
       spyOn($,'ajax');
       var called = false;
       var callback = function(){


### PR DESCRIPTION
This is unneeded and not supported by Spotify @PeterBell @aturkewi @mendelB @cjbrock 